### PR TITLE
Allow "closed" entries as editable

### DIFF
--- a/src/Types.elm
+++ b/src/Types.elm
@@ -294,7 +294,7 @@ entryEditable e =
             False
 
         _ ->
-            not e.closed
+            True
 
 
 latestEditableEntry : HoursResponse -> Maybe Entry


### PR DESCRIPTION
This field's meaning is unclear, but preventing making entries with it seems to cause problems for people logging hours, so it seems the only route is to ignore it.