### PR TITLE
Fix default entry for new employees

### DIFF
--- a/src/Types.elm
+++ b/src/Types.elm
@@ -464,6 +464,29 @@ entryDecoder =
         |> hardcoded Old
 
 
+makeEntry : Day -> NDTh -> List (Project ReportableTask) -> Entry
+makeEntry date defaultHours projects =
+    let
+        project =
+            List.head projects
+
+        task =
+            project
+                |> Maybe.map .tasks
+                |> Maybe.andThen List.head    
+    in    
+    { id = 0
+    , projectId = Maybe.map .id project |> Maybe.withDefault 0
+    , taskId = Maybe.map .id task |> Maybe.withDefault 0
+    , day = date
+    , description = Default "description here"
+    , closed = False
+    , hours = defaultHours
+    , billable = Billable
+    , age = New
+    }
+
+
 isEntryDeleted : Entry -> Bool
 isEntryDeleted e =
     case e.age of

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -61,19 +61,28 @@ update msg model =
 
                 OpenDay date hoursDay ->
                     let
+                        defaultHours =
+                            model.hours
+                                |> Maybe.map .defaultWorkHours
+                                |> Maybe.withDefault 7.5
+
+                        projects =
+                            model.hours
+                                |> Maybe.map .reportableProjects
+                                |> Maybe.withDefault []
+
                         latest =
                             Maybe.andThen T.latestEditableEntry model.hours
                                 |> Maybe.map (\e -> { e | id = e.id + 1, day = date, age = T.New, description = T.filledToDefault e.description })
+                                |> Maybe.withDefault (T.makeEntry date defaultHours projects)
 
                         addEntryIfEmpty =
                             if List.isEmpty hoursDay.entries then
                                 { hoursDay
                                     | entries =
-                                        Maybe.map List.singleton latest
-                                            |> Maybe.withDefault []
+                                        List.singleton latest
                                     , hours =
-                                        Maybe.map .hours latest
-                                            |> Maybe.withDefault 0
+                                        latest.hours
                                 }
 
                             else
@@ -85,6 +94,16 @@ update msg model =
 
                 AddEntry date ->
                     let
+                        defaultHours =
+                            model.hours
+                                |> Maybe.map .defaultWorkHours
+                                |> Maybe.withDefault 7.5
+
+                        projects =
+                            model.hours
+                                |> Maybe.map .reportableProjects
+                                |> Maybe.withDefault []
+                                
                         mostRecentEdit =
                             model.editingHours
                                 |> Dict.get date
@@ -98,7 +117,7 @@ update msg model =
                             Util.maybeOr mostRecentEdit (Maybe.andThen T.latestEditableEntry model.hours)
                                 |> Maybe.map (\e -> { e | id = e.id + 1, day = date, age = T.New, description = T.filledToDefault e.description })
                                 |> Maybe.map List.singleton
-                                |> Maybe.withDefault []
+                                |> Maybe.withDefault [T.makeEntry date defaultHours projects]
 
                         insertNew =
                             model.editingHours


### PR DESCRIPTION
Previously, if an employee had no prior hours logging, this would break as there was no default value for the UI to find when opening their first day.

This should hopefully create a workable default.