### PR TITLE
Stricter checking of editable entries

### DIFF
--- a/src/Api.elm
+++ b/src/Api.elm
@@ -88,8 +88,8 @@ wait =
         |> Task.perform (\_ -> NoOp)
 
 
-updateHoursDay : T.HoursDay -> List (Cmd Msg)
-updateHoursDay hoursDay =
+updateHoursDay : Maybe T.HoursResponse -> T.HoursDay -> List (Cmd Msg)
+updateHoursDay hours hoursDay =
     let
         whichCmd e =
             case e.age of
@@ -105,7 +105,7 @@ updateHoursDay hoursDay =
                 T.DeletedNew ->
                     Cmd.none
     in
-    List.filter T.entryEditable hoursDay.entries
+    List.filter (T.entryEditable hours) hoursDay.entries
         |> List.map whichCmd 
         |> List.intersperse wait
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -284,8 +284,8 @@ latestEntry hours =
         |> List.head
 
 
-entryEditable : Entry -> Bool
-entryEditable e =
+entryEditable : Maybe HoursResponse -> Entry -> Bool
+entryEditable hours e =
     case e.billable of
         Absence ->
             False
@@ -294,22 +294,21 @@ entryEditable e =
             False
 
         _ ->
-            True
-
-
-latestEditableEntry : HoursResponse -> Maybe Entry
-latestEditableEntry hours =
-    allEntries hours
-        |> List.filter entryEditable
-        |> List.reverse
-        |> List.head
+            Maybe.map (\h -> List.member e.projectId <| List.map .id h.reportableProjects) hours
+                |> Maybe.withDefault False
 
 
 latestEditableEntries : HoursResponse -> List Entry
 latestEditableEntries hours =
     allEntries hours
-        |> List.filter entryEditable
+        |> List.filter (entryEditable <| Just hours)
         |> List.reverse
+
+
+latestEditableEntry : HoursResponse -> Maybe Entry
+latestEditableEntry hours =
+    latestEditableEntries hours
+        |> List.head
 
 
 oldestEntry : HoursResponse -> Maybe Entry

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -115,7 +115,7 @@ update msg model =
                                 |> Maybe.map (List.sortBy .id)
                                 |> Maybe.map List.reverse
                                 |> Maybe.andThen List.head
-                                |> MX.filter T.entryEditable
+                                |> MX.filter (T.entryEditable model.hours)
 
                         newEntry =
                             Util.maybeOr mostRecentEdit (Maybe.andThen T.latestEditableEntry model.hours)
@@ -203,7 +203,7 @@ update msg model =
                         tempHours =
                             Maybe.map addHours model.hours
                     in
-                    case Api.updateHoursDay hoursDay of
+                    case Api.updateHoursDay model.hours hoursDay of
                         [] ->
                             ( { model | hasError = Just "Saved day had no hours entries" }, Cmd.none )
 
@@ -263,7 +263,7 @@ update msg model =
                                 |> Maybe.map .entries
                                 |> Maybe.map List.reverse
                                 |> Maybe.andThen List.head
-                                |> MX.filter T.entryEditable
+                                |> MX.filter (T.entryEditable model.hours)
                                 |> (\e -> Util.maybeOr e latest)
                                 |> Maybe.map (\e -> { e | id = e.id + 1, age = T.New, description = T.filledToDefault e.description })
                                 |> Maybe.map List.singleton


### PR DESCRIPTION
THE WAR CONTINUES

Had an issue where we weren't always checking properly that a project was from the `reportableProjects` field and stuff was still sneaking through.