### PR TITLE
Filter absences from reportable and grab 60 days on first load

### DIFF
--- a/src/Model.elm
+++ b/src/Model.elm
@@ -59,10 +59,10 @@ init flags =
         today =
             Time.millisToPosix flags.now
 
-        thirtyDaysAgo =
+        sixtyDaysAgo =
             flags.now
                 |> Time.millisToPosix
-                |> TE.add TE.Day -30 Time.utc
+                |> TE.add TE.Day -60 Time.utc
     in
     ( { isMenuOpen = False
       , user = Nothing
@@ -80,6 +80,6 @@ init flags =
       }
     , Cmd.batch
         [ Api.fetchUser
-        , Api.fetchHours thirtyDaysAgo today
+        , Api.fetchHours sixtyDaysAgo today
         ]
     )

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -59,10 +59,10 @@ init flags =
         today =
             Time.millisToPosix flags.now
 
-        sixtyDaysAgo =
+        thirtyDaysAgo =
             flags.now
                 |> Time.millisToPosix
-                |> TE.add TE.Day -60 Time.utc
+                |> TE.add TE.Day -30 Time.utc
     in
     ( { isMenuOpen = False
       , user = Nothing
@@ -80,6 +80,6 @@ init flags =
       }
     , Cmd.batch
         [ Api.fetchUser
-        , Api.fetchHours sixtyDaysAgo today
+        , Api.fetchHours thirtyDaysAgo today
         ]
     )

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -213,6 +213,16 @@ mergeHoursResponse newHours oldHours =
         )
 
 
+sanitizeHoursResponse: HoursResponse -> HoursResponse
+sanitizeHoursResponse hours =
+    let
+        cleanProjects =
+            hours.reportableProjects
+                |> List.filter (not << String.contains "Absence" << .name)
+    in
+        { hours | reportableProjects = cleanProjects }
+
+
 hoursToProjectDict : HoursResponse -> Dict Identifier String
 hoursToProjectDict hours =
     let

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -71,7 +71,7 @@ update msg model =
                             model.hours
                                 |> Maybe.map .reportableProjects
                                 |> Maybe.withDefault []
-                                |> List.filter (\rp -> String.contains "Absence" rp.name)
+                                |> List.filter (\rp -> not <| String.contains "Absence" rp.name)
 
                         latest =
                             Maybe.andThen T.latestEditableEntry model.hours
@@ -336,9 +336,10 @@ update msg model =
                                     case model.hours of
                                         Just oldHours ->
                                             T.mergeHoursResponse oldHours hoursResponse
+                                                |> T.sanitizeHoursResponse
 
                                         Nothing ->
-                                            hoursResponse
+                                            T.sanitizeHoursResponse hoursResponse
                             in
                             ( { model
                                 | hours = Just newHours

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -348,7 +348,10 @@ update msg model =
                                 , allDays = T.allDaysAsDict newHours
                                 , isLoading = False
                               }
-                            , Cmd.none
+                            , if List.isEmpty newHours.reportableProjects then 
+                                Msg.send LoadMorePrevious
+                              else 
+                                Cmd.none
                             )
 
                         Err err ->
@@ -361,6 +364,7 @@ update msg model =
                                 newHours =
                                     model.hours
                                         |> Maybe.map (T.mergeHoursResponse resp.hours)
+                                        |> Maybe.map T.sanitizeHoursResponse
 
                                 newDays =
                                     Maybe.map T.allDaysAsDict newHours


### PR DESCRIPTION
This filters absences from the reportable projects list, weakly so as it has to match by name as `reportableTasks`, don't have the `absence` field.

It also changes the initial load to 60 from 30 days, as fewer people go on summer holiday longer than 30 days, this will at least reduce the frequency of problems.

This is something of a hacky solution, but without digging deeper into the API logic, is probably the easiest fix.