### PR TITLE
Patch: local dev setup complaining about fonts not found

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,7 +1,8 @@
 {
     "type": "application",
     "source-directories": [
-        "src"
+        "src",
+        "public"
     ],
     "elm-version": "0.19.1",
     "dependencies": {

--- a/src/main.css
+++ b/src/main.css
@@ -11,18 +11,18 @@
 
 @font-face {
   font-family: FuturiceSans;
-  src: url('/FuturiceRegular.otf');
+  src: url('/public/FuturiceRegular.otf');
 }
 
 @font-face {
   font-family: FuturiceSans;
   font-weight: bold;
-  src: url('/FuturiceBold.otf');
+  src: url('/public/FuturiceBold.otf');
 }
 
 @font-face {
   font-family: FuturiceMono;
-  src: url('/FuturiceMono.otf');
+  src: url('/public/FuturiceMono.otf');
 }
 
 body {
@@ -56,7 +56,7 @@ img {
   font-size: 16px;
   font-weight: lighter;
   width: 100%;
-  background-image: url('/angle-down-solid.svg'), linear-gradient(#ffffff, #ffffff);
+  background-image: url('/public/angle-down-solid.svg'), linear-gradient(#ffffff, #ffffff);
   background-size: 16px;
   background-repeat: no-repeat;
   background-position: right 10px center;


### PR DESCRIPTION
Changes:
 - Add public directory to source directories
 - Use the new public directory to avoid having to copy bin files to the source directory

Fixes:
 - Local development setup (`elm-app start`) doesn't complains about font not in the `src/` directory


Signed-off-by: Jae Lo Presti <jae.lopresti@futurice.com>